### PR TITLE
ccp in sdk

### DIFF
--- a/my-docs/docs/websdk/APIReference/setConsent.md
+++ b/my-docs/docs/websdk/APIReference/setConsent.md
@@ -29,6 +29,7 @@ The `consentObject` is a JavaScript object containing key-value pairs. It includ
 #### `cookieSync` (`boolean`)
 - `true`: Allows cookie syncing.
 - `false`: Disables cookie syncing.
+- To control cookie syncing consent per individual channel partner, configure [`partnerConsentKeyMap`](../Configurations/partnerConsentKeyMap) during `init`.
 
 ### Brand Consent Keys
 

--- a/my-docs/docs/websdk/Configurations/configurations.md
+++ b/my-docs/docs/websdk/Configurations/configurations.md
@@ -35,6 +35,7 @@ Only works for PIIs (cellno, email, loginid) sent using [setUserIdentities](../A
 | [`purposesForCookieSync`](./consentOptions#purposesforcookiesyncing)            | Number[]                                 | TCF Purpose IDs required for cookie syncing. Default depends on TCF version/config (e.g., `[1,3,4]` or `[1,5,6]`).                                             |
 | [`includeTCFString`](./consentOptions#includetcfstring)                     | Boolean                                  | If `true`, the TCF consent string is included in the event payload regardless of the consent mechanism used. No default specified.                              |
 | [`shouldCheckZeotapVendorConsent`](./consentOptions#shouldcheckzeotapvendorconsent)     | Boolean                                  | If `true`, the SDK checks for Zeotap's vendor consent (ID 1469) before checking tracking purposes. Defaults to `false`.                                           |
+| [`partnerConsentKeyMap`](./partnerConsentKeyMap)     | Object                                  | Maps keys in your `setConsent` call to Zeotap Partner IDs to control cookie syncing consent per channel partner (e.g. Google, Meta). Only active in custom consent mode (`useConsent: true`, `checkForCMP: false`). Defaults to `undefined`. |
 
 [Learn more about combined usage of consent options](./consentOptions#combined-usage)
 

--- a/my-docs/docs/websdk/Configurations/partnerConsentKeyMap.md
+++ b/my-docs/docs/websdk/Configurations/partnerConsentKeyMap.md
@@ -1,0 +1,115 @@
+---
+sidebar_position: 6
+title: Consent Based cookie syncing
+description: Consent to channels to cookie sync to.
+---
+
+# Consent based cookie syncing
+
+## Overview
+
+`partnerConsentKeyMap` lets you control Zeotap's cookie syncing feature on a per-channel-partner basis. By default, the `cookieSync` key in `setConsent` enables or disables cookie syncing globally across all partners. With `partnerConsentKeyMap`, you can grant or deny cookie sync consent for individual partners (e.g. Google, Meta) independently.
+
+You define a mapping of **Zeotap Partner ID** → **key you use in your `setConsent` call**. When `setConsent` is called, the SDK reads those keys and determines which partners are consented for cookie syncing.
+
+This feature is only active in **custom consent mode** (`useConsent: true`, `checkForCMP: false`).
+
+---
+
+## How It Works
+
+1. Define `partnerConsentKeyMap` in your `init` options — a map of Zeotap Partner ID to the key you will pass in `setConsent`.
+2. Call `setConsent` with those keys set to `true` or `false`.
+3. The SDK extracts the partner-specific values and uses them to control cookie syncing for each partner individually.
+4. These keys are forwarded to Zeotap as **Consented Channel Partners (CCP)**.
+
+---
+
+## Setup
+
+### Step 1 — Configure during `init`
+
+```js
+zeotap.init('YOUR_WRITE_KEY', {
+  useConsent: true,
+  checkForCMP: false,
+  partnerConsentKeyMap: {
+    "22": "google_cookie_sync_consent",
+    "35": "meta_cookie_sync_consent"
+  }
+});
+```
+
+| Option | Type | Description |
+|---|---|---|
+| `useConsent` | `boolean` | Must be `true` to enable custom consent mode |
+| `checkForCMP` | `boolean` | Must be `false` to use custom consent (not TCF/CMP) |
+| `partnerConsentKeyMap` | `object` | Map of Zeotap Partner ID → key used in `setConsent` to control cookie sync consent for that partner |
+
+### Step 2 — Call `setConsent` with partner cookie sync keys
+
+```js
+zeotap.setConsent({
+  track: true,
+  cookieSync: true,                      // global cookie sync consent
+  google_cookie_sync_consent: true,      // cookie sync consented for partner ID "22"
+  meta_cookie_sync_consent: false        // cookie sync denied for partner ID "35"
+});
+```
+
+---
+
+## How the SDK Processes the Consent Object
+
+Given the above example:
+
+| Key | Value | Processed As |
+|---|---|---|
+| `track` | `true` | Primary consent — controls event tracking |
+| `cookieSync` | `true` | Primary consent — controls global cookie syncing |
+| `google_cookie_sync_consent` | `true` | Cookie sync consented for partner ID `"22"` |
+| `meta_cookie_sync_consent` | `false` | Cookie sync denied for partner ID `"35"` |
+
+---
+
+## Full Example
+
+```html
+<script>
+  window.zeotap = window.zeotap || { _q: [] };
+
+  zeotap.init('YOUR_WRITE_KEY', {
+    useConsent: true,
+    checkForCMP: false,
+    partnerConsentKeyMap: {
+      "22": "google_cookie_sync_consent",
+      "35": "meta_cookie_sync_consent"
+    }
+  });
+
+  // Call after user makes a consent choice via your CMP/consent UI
+  zeotap.setConsent({
+    track: true,
+    cookieSync: true,
+    google_cookie_sync_consent: true,
+    meta_cookie_sync_consent: false
+  });
+</script>
+```
+
+---
+
+## Notes
+
+- `partnerConsentKeyMap` must be a plain object. Keys are Zeotap Partner IDs and values are the corresponding keys in your `setConsent` call.
+- Partner consent keys are extracted before the consent object is processed, so they will not appear in the brand consent payload.
+- If `partnerConsentKeyMap` is not set or is not a valid object, the SDK skips partner-level cookie sync consent extraction.
+- This feature has **no effect** when `useConsent` is `false` or `checkForCMP` is `true` (TCF/CMP mode).
+
+---
+
+## Supported Channel Partners
+
+:::note
+To get the full list of supported Zeotap Partner IDs contact support.
+:::

--- a/my-docs/docs/websdk/Consent/customConsent.md
+++ b/my-docs/docs/websdk/Consent/customConsent.md
@@ -39,5 +39,25 @@ window.zeotap.init("YOUR_WRITE_KEY", {
 
 See detailed guide about [```window.zeotap.setConsent()```](../APIReference/setConsent)
 
-Try out this <a href="https://github.com/zeotap/zeotap-web-sdk-docs/tree/main/my-docs/static/examples/consent/customConsent" target="_blank">example</a>. 
+To control cookie syncing consent per individual channel partner, you can also configure [`partnerConsentKeyMap`](../Configurations/partnerConsentKeyMap) during `init`. This lets you grant or deny Zeotap's cookie syncing for specific partners (e.g. Google, Meta) independently, by mapping partner IDs to keys in your `setConsent` call.
+
+```jsx title="Using partnerConsentKeyMap with Custom Consent"
+window.zeotap.init("YOUR_WRITE_KEY", {
+  useConsent: true,
+  checkForCMP: false,
+  partnerConsentKeyMap: {
+    "22": "google_cookie_sync_consent",
+    "35": "meta_cookie_sync_consent"
+  }
+});
+
+window.zeotap.setConsent({
+  track: true,
+  cookieSync: true,                      // global cookie sync consent
+  google_cookie_sync_consent: true,      // cookie sync consented for partner ID "22"
+  meta_cookie_sync_consent: false        // cookie sync denied for partner ID "35"
+});
+```
+
+Try out this <a href="https://github.com/zeotap/zeotap-web-sdk-docs/tree/main/my-docs/static/examples/consent/customConsent" target="_blank">example</a>.
 

--- a/my-docs/docs/websdk/FAQs/cookieSync.md
+++ b/my-docs/docs/websdk/FAQs/cookieSync.md
@@ -14,6 +14,7 @@ Zeotap CDP allows you to collect user web data from different platforms and targ
 - Channel cookies are mapped to the Zeotap cookie and any user identifiers you send.
 - Syncs are fired as image pixels or iframe tags.
 - Web image pixels can sync with only one partner per call; the highest-priority partner is selected.
+- To control cookie syncing consent per individual channel partner, configure [`partnerConsentKeyMap`](../Configurations/partnerConsentKeyMap) during `init`.
 
 
 :::note


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Document how <code>partnerConsentKeyMap</code> augments the SDK’s consent configuration so that <code>init</code> and <code>setConsent</code> can control cookie syncing consent per Zeotap partner alongside the global <code>cookieSync</code> flag. Highlight the added reference page and documentation updates that explain how to use the option inside custom consent flows and FAQs.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>rishabh-zeo</td><td>Vendor-id-message-chan...</td><td>December 16, 2025</td></tr>
<tr><td>rishabh@ZT-Mac-IN-Rish...</td><td>Tag-Managers</td><td>June 04, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/zeotap/zeotap-web-sdk-docs/26?tool=ast>(Baz)</a>.