### PR TITLE
Clarify cookie syncing behavior in documentation

### DIFF
--- a/my-docs/docs/websdk/Configurations/allowCookieSync.md
+++ b/my-docs/docs/websdk/Configurations/allowCookieSync.md
@@ -14,7 +14,7 @@ description: Enable/Disable cookie syncing functionality.
 
 This option controls whether the Zeotap Web SDK is permitted to perform **cookie syncing** operations. Cookie syncing is a background process used to match the Zeotap user identifier (ZI) with identifiers from approved third-party advertising platforms or data partners. This matching typically happens via pixel fires or redirects initiated by the SDK.
 
-*   **`true` (Default):** When set to `true`, the SDK will automatically initiate cookie syncing processes with configured partners when appropriate conditions are met (e.g., necessary user consent is available). This helps in building a more comprehensive view of the user across different platforms and enables functionalities like audience retargeting or extension.
+*   **`true` (Default):** When set to `true`, the SDK will automatically initiate cookie syncing processes with all partners. To restrict reach out to Zeotap represtative or Support team. 
 *   **`false`:** When set to `false`, the SDK will **not** perform any automatic cookie syncing operations, regardless of consent status.
 
 **Usage:**


### PR DESCRIPTION
Updated the description of the 'true' option for cookie syncing to clarify that it initiates processes with all partners and advises contacting Zeotap for restrictions.