### PR TITLE
fix(adobe): register missing docs plugin so Adobe documentation resolves

### DIFF
--- a/my-docs/docusaurus.config.js
+++ b/my-docs/docusaurus.config.js
@@ -91,6 +91,17 @@ const config = {
         showLastUpdateTime: true
       },
     ],
+    [
+      '@docusaurus/plugin-content-docs',
+      {
+        id: 'adobe',
+        path: 'docs/adobe',
+        routeBasePath: 'adobeLaunch/docs',
+        sidebarPath: './sidebars.js',
+        breadcrumbs: true,
+        showLastUpdateTime: true
+      },
+    ],
     // [
     //   '@docusaurus/plugin-content-blog',
     //   {


### PR DESCRIPTION
## Problem
The navbar **Adobe → Documentation** links to `/adobeLaunch/docs/intro`, but clicking it lands on Docusaurus's **"Page Not Found"** screen.

## Root cause
Every other SDK (WebSDK, GTM, Android, iOS, React Native) registers a `@docusaurus/plugin-content-docs` instance in `docusaurus.config.js`. **Adobe had none.** The `docs/adobe/` content (`intro.md`, `configure.md`, `installation.md`, `Actions/*`) existed but no plugin served a route for it, so the `/adobeLaunch/docs/*` URLs were never registered and fell through to the 404 page.

## Fix
Add the missing Adobe docs plugin, matching the other SDKs:

```js
[
  '@docusaurus/plugin-content-docs',
  {
    id: 'adobe',
    path: 'docs/adobe',
    routeBasePath: 'adobeLaunch/docs',
    sidebarPath: './sidebars.js',
    breadcrumbs: true,
    showLastUpdateTime: true
  },
],
```

## Verification
Restarted the dev server (config isn't hot-reloaded) and confirmed `.docusaurus/routes.js` now registers all 6 Adobe pages:
- `adobeLaunch/docs/intro`, `/configure`, `/installation`
- `adobeLaunch/docs/Actions/{setCustomConsent, syncUserIdentity, trackEvents}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)